### PR TITLE
better contiguous spaces handling in class lists

### DIFF
--- a/chibi.js
+++ b/chibi.js
@@ -356,7 +356,7 @@ You should have received a copy of the GNU General Public License along with thi
 
 				if (classes) {
 					// Trim any whitespace
-					classarray = classes.split(' ');
+					classarray = classes.split(/\s+/);
 					action = action || 'replace';
 				}
 
@@ -402,6 +402,7 @@ You should have received a copy of the GNU General Public License along with thi
 
 							break;
 						}
+						elm.className = elm.className.replace(/^\s+|\s+$/g, '');
 					}
 					else
 					{


### PR DESCRIPTION
Note: I did not update chibi-min.

This commit allows for:

``` javascript
$(selector).cls("classA   classB classC          classD")
```

to properly set class attribute to `classA classB classC classD`.

More importantly, it also ensures the class attribute value is stripped on replace / remove actions so that:

``` html
<p class="classA classB">test</p>
```

``` javascript
$(".classA").cls("classB", "remove");
```

without patch (notice the space):

``` html
<p class="classA ">test</p>
```

with patch:

``` html
<p class="classA">test</p>
```
