### PR TITLE
add error message for css unable to be set

### DIFF
--- a/chibi.js
+++ b/chibi.js
@@ -77,11 +77,13 @@
 		return encodeURIComponent(name).replace(/%20/g, '+') + '=' + encodeURIComponent(value).replace(/%20/g, '+');
 	}
 
-	// Set CSS, important to wrap in try to prevent error thown on unsupported property
+	// Set CSS, important to wrap in try to prevent error thrown on unsupported property
 	function setCss(elm, property, value) {
 		try {
 			elm.style[cssCamel(property)] = value;
-		} catch (e) {}
+		} catch (e) {
+			console.error('Could not set css style property "' + property + '".');
+		}
 	}
 
 	// Show CSS


### PR DESCRIPTION
I think an error message should be displayed for not being able to set a css property so debugging and be easier on the user. I also fixed a typo. 